### PR TITLE
Make rc-tools work with npm3

### DIFF
--- a/lib/gulpfile.js
+++ b/lib/gulpfile.js
@@ -16,7 +16,7 @@ var fs = require('fs');
 gulp.task('browser-test', function (done) {
   startServer(function (port) {
     var server = this;
-    var mochaPhantomjsBin = path.join(__dirname, '../node_modules/.bin/mocha-phantomjs');
+    var mochaPhantomjsBin = require.resolve('mocha-phantomjs/bin/mocha-phantomjs');
     shelljs.exec([mochaPhantomjsBin, 'http://localhost:' + port + '/tests/runner.html'].join(' '), function (code) {
       server.close(function (error) {
         done(error || code);
@@ -29,7 +29,7 @@ gulp.task('browser-test', function (done) {
 gulp.task('browser-test-cover', function (done) {
   startServer(function (port) {
     var server = this;
-    var mochaPhantomjsBin = path.join(__dirname, '../node_modules/.bin/mocha-phantomjs');
+    var mochaPhantomjsBin = require.resolve('mocha-phantomjs/bin/mocha-phantomjs');
     shelljs.exec([mochaPhantomjsBin, '-R',
       'node_modules/rc-server/node_modules/node-jscover-coveralls/lib/reporters/mocha',
       'http://localhost:' + port + '/tests/runner.html?coverage'].join(' '), function (code) {
@@ -41,7 +41,7 @@ gulp.task('browser-test-cover', function (done) {
 });
 
 gulp.task('lint', ['check-deps'], function (done) {
-  var eslintBin = path.join(__dirname, '../node_modules/.bin/eslint');
+  var eslintBin = require.resolve('eslint/bin/eslint');
   var eslintConfig = path.join(__dirname, './eslintrc');
   var args = [eslintBin, '-c', eslintConfig, '--ext', '.js,.jsx', 'src'];
   runCmd('node', args, done);
@@ -190,7 +190,7 @@ gulp.task('my-saucelabs', function (done) {
 });
 
 gulp.task('saucelabs', function (done) {
-  var karmaBin = path.join(__dirname, '../node_modules/.bin/karma');
+  var karmaBin = require.resolve('karma-cli/bin/karma');
   var karmaConfig = path.join(__dirname, './karma.saucelabs.conf.js');
   var args = [karmaBin, 'start', karmaConfig];
   runCmd('node', args, done);
@@ -209,7 +209,7 @@ gulp.task('check-deps', function (done) {
 });
 
 gulp.task('karma', function (done) {
-  var karmaBin = path.join(__dirname, '../node_modules/.bin/karma');
+  var karmaBin = require.resolve('karma-cli/bin/karma');
   var karmaConfig = path.join(__dirname, './karma.conf.js');
   var args = [karmaBin, 'start', karmaConfig];
   if (process.argv.indexOf('--single-run') !== -1) {


### PR DESCRIPTION
Npm3 has flatten dependency tree, so your paths to tools doesn't work anymore.

`require.resolve` is a mechanism to get the actual path to installed module. This make it work on both versions 2 and 3