### PR TITLE
Change cli log for increased clarity

### DIFF
--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -22,7 +22,7 @@ if (!task) {
   program.help();
 } else if (task === 'server') {
   var port = process.env.npm_package_config_port || 8000;
-  console.log(`listen at ${port}`);
+  console.log(`Listening at http://localhost:${port}`);
   var app = require('../server/')();
   app.listen(port);
 } else {


### PR DESCRIPTION
When `listen at 8007` appeared in my console I had to think for a second
what it meant, so to prevent users from being confused I think it is
better to log this message.