### PR TITLE
Add support for configuring dist webpack output via package.json

### DIFF
--- a/lib/gulpfile.js
+++ b/lib/gulpfile.js
@@ -136,16 +136,20 @@ gulp.task('dist', (done) => {
       inlineSourceMap: false,
     }), { phase: 'dist' });
   } else {
+    const output = pkg.output;
+    if (output && output.library === null) {
+      output.library = undefined;
+    }
     webpackConfig = assign(getWebpackConfig({
       common: false,
       inlineSourceMap: false,
     }), {
-      output: {
+      output: Object.assign({
         path: path.join(cwd, 'dist'),
         filename: '[name].js',
         library: pkg.name,
         libraryTarget: 'umd',
-      },
+      }, output),
       externals: {
         react: {
           root: 'React',


### PR DESCRIPTION
This change allows customizing webpack's output configuration via an `ouput` Object in the lib package.json, as mentioned in #31. output config in package.json will overwrite defaults, and `library: null` will be converted into `library: undefined` for webpack. For example, this would attach a library's named exports to the UMD export:

```json
// in lib's package.json
{
  "output": {
    "library": null,
    "umdNamedDefine": true
  }
}
```