### PR TITLE
Use babel plugin for module path replacement

### DIFF
--- a/lib/getWebpackCommonConfig.js
+++ b/lib/getWebpackCommonConfig.js
@@ -10,6 +10,7 @@ const getBabelCommonConfig = require('./getBabelCommonConfig');
 const tsConfig = require('./getTSCommonConfig')();
 const constants = require('./constants');
 const assign = require('object-assign');
+const replaceLib = require('./replaceLib');
 
 delete tsConfig.noExternalResolve;
 
@@ -66,9 +67,13 @@ module.exports = {
   },
   getLoaders(c) {
     const commonjs = c || false;
+    const babelConfig = getBabelCommonConfig(commonjs);
+    if (commonjs === false) {
+      babelConfig.plugins.push(replaceLib);
+    }
     const babelLoader = {
       loader: 'babel',
-      options: getBabelCommonConfig(commonjs),
+      options: babelConfig,
     };
     return [
       assign({

--- a/lib/gulpfile.js
+++ b/lib/gulpfile.js
@@ -28,13 +28,13 @@ const glob = require('glob');
 const watch = require('gulp-watch');
 const assign = require('object-assign');
 const { tsCompiledDir } = require('./constants');
-const matchRequire = require('match-require');
 const targz = require('tar.gz');
 const request = require('request');
 const {
   measureFileSizesBeforeBuild,
   printFileSizesAfterBuild,
 } = require('./FileSizeReporter');
+const replaceLib = require('./replaceLib');
 
 const tsDefaultReporter = ts.reporter.defaultReporter();
 const src = argv.src || 'src';
@@ -290,36 +290,15 @@ function babelifyInternal(js, modules) {
   function replacer(match, m1, m2) {
     return `${m1}/assets/${m2}.css`;
   }
+  const babelConfig = getBabelCommonConfig(modules);
+  if (modules === false) {
+    babelConfig.plugins.push(replaceLib);
+  }
 
-  return js.pipe(babel(getBabelCommonConfig(modules)))
+  return js.pipe(babel(babelConfig))
     .pipe(through2.obj(function (file, encoding, next) {
-      let contents = file.contents.toString(encoding)
+      const contents = file.contents.toString(encoding)
         .replace(lessPath, replacer);
-
-      if (modules === false) {
-        const deps = matchRequire.findAll(contents);
-        const needs = {};
-        const hasLib = deps.some(d => {
-          const has = d.indexOf('/lib/') !== -1;
-          if (!has) {
-            return false;
-          }
-          const es = d.replace('/lib/', '/es/');
-          const esPath = path.dirname(path.join(cwd, `node_modules/${es}`));
-          if (!fs.existsSync(esPath)) {
-            console.log('lib is not replaced by es, can not find:', esPath);
-            return false;
-          }
-          needs[d] = es;
-          return has;
-        });
-        if (hasLib) {
-          contents = matchRequire.replaceAll(contents, (dep) => {
-            return needs[dep] || dep;
-          });
-        }
-      }
-
       file.contents = new Buffer(contents, encoding);
       this.push(file);
       next();

--- a/lib/replaceLib.js
+++ b/lib/replaceLib.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const { join, dirname } = require('path');
+const fs = require('fs');
+
+const cwd = process.cwd();
+
+function replacePath(path) {
+  if (path.node.source && /\/lib\//.test(path.node.source.value)) {
+    const esModule = path.node.source.value.replace('/lib/', '/es/');
+    const esPath = dirname(join(cwd, `node_modules/${esModule}`));
+    if (fs.existsSync(esPath)) {
+      console.log(`[es build] replace ${path.node.source.value} with ${esModule}`);
+      path.node.source.value = esModule;
+    }
+  }
+}
+
+function replaceLib() {
+  return {
+    visitor: {
+      ImportDeclaration: replacePath,
+      ExportNamedDeclaration: replacePath,
+    },
+  };
+}
+
+module.exports = replaceLib;


### PR DESCRIPTION
同 https://github.com/ant-design/antd-tools/pull/46

另外当前实现有 bug ，见 https://unpkg.com/rc-trigger@1.11.4/es/index.js `rc-util/lib/Dom/addEventListener` 没被替换过来。