### PR TITLE
add es6 shim

### DIFF
--- a/lib/server/packageUtil.js
+++ b/lib/server/packageUtil.js
@@ -6,6 +6,7 @@ var NODE_MODULES = 'node_modules';
 var utils = require('modulex-util');
 var packages = {
   es5Shim: 1,
+  es6Shim: 1,
   es6Promise: 1,
   normalize: 'normalize.css',
   consolePolyfill: 1,

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "css-loader": "^0.26.1",
     "es5-shim": "4.x",
     "es6-promise": "~3.2.1",
+    "es6-shim": "^0.35.3",
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "^5.0.1",
     "eslint-plugin-react": "^3.16.1",

--- a/views/js2html.xtpl
+++ b/views/js2html.xtpl
@@ -6,6 +6,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <title>{{pkg.name}}-{{name}}</title>
     <link href="/{{normalize}}/normalize.css" type="text/css" rel="stylesheet"/>
+    <script src="/{{es6Shim}}/es6-shim.js"></script>
+    <script src="/{{es6Shim}}/es6-sham.js"></script>
     <script src="/{{es5Shim}}/es5-shim.js"></script>
     <script src="/{{es5Shim}}/es5-sham.js"></script>
     <script src="/{{consolePolyfill}}/index.js"></script>


### PR DESCRIPTION
React 16.2 add `VALID_FRAGMENT_PROPS` using `Map` which cause crash in IE 10 and below.
Add es6 shim to fix that.

ref: https://github.com/facebook/react/issues/11841