### PR TITLE
add react 15 test support

### DIFF
--- a/lib/getBabelCommonConfig.js
+++ b/lib/getBabelCommonConfig.js
@@ -25,7 +25,6 @@ module.exports = function(modules) {
         require.resolve(`babel-preset-env`),
         {
           modules,
-          loose: true,
           exclude: ['transform-es2015-typeof-symbol'],
         },
       ],

--- a/lib/gulpfile.js
+++ b/lib/gulpfile.js
@@ -38,6 +38,57 @@ const lessPath = new RegExp(`(["']${pkg.name})/assets/([^.'"]+).less`, 'g');
 const tsDefaultReporter = ts.reporter.defaultReporter();
 const src = argv.src || 'src';
 
+const mockRcTrigger = `
+import React from 'react';
+
+let Trigger;
+
+const ActualTrigger = require.requireActual('rc-trigger');
+const render = ActualTrigger.prototype.render;
+
+ActualTrigger.prototype.render = function () {
+  const { popupVisible } = this.state;
+  let component;
+
+  if (popupVisible || this._component) {
+    component = this.getComponent();
+  }
+
+  return (
+    <div id="TriggerContainer">
+      {render.call(this)}
+      {component}
+    </div>
+  );
+};
+Trigger = ActualTrigger;
+
+export default Trigger;
+`;
+
+const mockRcPortal = `
+import React from 'react';
+
+export default class Portal extends React.Component {
+  componentDidMount() {
+    this.createContainer();
+  }
+
+  createContainer() {
+    this.container = true;
+    this.forceUpdate();
+  }
+
+  render() {
+    const { children } = this.props;
+    if (this.container) {
+      return children;
+    }
+    return null;
+  }
+}
+`;
+
 gulp.task('js-lint', ['check-deps'], done => {
   if (argv['js-lint'] === false) {
     return done();
@@ -579,4 +630,35 @@ gulp.task('prettier', () => {
       )
     )
     .pipe(gulp.dest(file => file.base));
+});
+
+gulp.task('test:react-15', (done) => {
+  console.log(chalk.yellow('Install react 15 dependenicy...'));
+  shelljs.exec('npm i --no-save react@15 react-dom@15 react-test-renderer@15 enzyme-adapter-react-15');
+
+  console.log(chalk.yellow('Read `tests/setup.js`...'));
+  const testSetup = resolveCwd('./tests/setup.js');
+  let content = fs.readFileSync(testSetup, 'UTF-8');
+
+  content = content.replace('enzyme-adapter-react-16', 'enzyme-adapter-react-15');
+
+  console.log(chalk.yellow('Modify `tests/setup.js` for `enzyme-adapter-react-15`...'));
+  fs.writeFileSync(testSetup, content, 'UTF-8');
+
+  // Add mock file
+  const mockDir = resolveCwd('./tests/__mocks__/');
+
+  console.log(chalk.yellow('Mock of `rc-trigger`...'));
+  fs.ensureDirSync(mockDir);
+  fs.writeFileSync(path.resolve(mockDir, 'rc-trigger.js'), mockRcTrigger, 'UTF-8');
+
+  console.log(chalk.yellow('Mock of `rc-util/lib/Portal.js`...'));
+  const rcUtilDir = path.resolve(mockDir, 'rc-util/lib');
+  fs.ensureDirSync(rcUtilDir);
+  fs.writeFileSync(path.resolve(rcUtilDir, 'Portal.js'), mockRcPortal, 'UTF-8');
+
+  console.log(chalk.yellow('Start test...'));
+  const ret = shelljs.exec('npx jest -u');
+
+  done(ret.code);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-tools",
-  "version": "8.1.4",
+  "version": "8.1.5",
   "description": "offline tools for react component",
   "keywords": [
     "react",


### PR DESCRIPTION
Add `test:react-15` cli for React 15 test usage. Pls help to check if I miss something.

Will add additional ci build step in travis matrix as `rc-tools run test:react-15`.