### PR TITLE
add pre-commit

### DIFF
--- a/lib/gulpfile.js
+++ b/lib/gulpfile.js
@@ -90,6 +90,7 @@ export default class Portal extends React.Component {
 `;
 
 gulp.task('js-lint', ['check-deps'], done => {
+  const fileList = (argv._ || []).slice(1);
   if (argv['js-lint'] === false) {
     return done();
   }
@@ -99,7 +100,18 @@ gulp.task('js-lint', ['check-deps'], done => {
   if (fs.existsSync(projectEslint)) {
     eslintConfig = projectEslint;
   }
-  const args = [eslintBin, '-c', eslintConfig, '--ext', '.js,.jsx', src, 'tests', 'examples'];
+  let args = [eslintBin, '-c', eslintConfig];
+  if (fileList.length) {
+    const regex = /\.jsx?$/i;
+    const jsFiles = fileList.filter(file => regex.test(file));
+    if (!jsFiles.length) {
+      done();
+      return;
+    }
+    args = args.concat(jsFiles);
+  } else {
+    args = args.concat(['--ext', '.js,.jsx', src, 'tests', 'examples']);
+  }
   if (argv.fix) {
     args.push('--fix');
   }
@@ -107,20 +119,35 @@ gulp.task('js-lint', ['check-deps'], done => {
 });
 
 gulp.task('ts-lint', ['check-deps'], done => {
+  const fileList = (argv._ || []).slice(1);
+
   const tslintBin = require.resolve('tslint/bin/tslint');
   let tslintConfig = path.join(__dirname, './tslint.json');
   const projectTslint = resolveCwd('./tslint.json');
   if (fs.existsSync(projectTslint)) {
     tslintConfig = projectTslint;
   }
-  const args = [
+  let args = [
     tslintBin,
     '-c',
     tslintConfig,
-    `${src}/**/*.tsx`,
-    'tests/**/*.tsx',
-    'examples/**/*.tsx',
   ];
+  if (fileList.length) {
+    const regex = /\.tsx$/i;
+    const tsFiles = fileList.filter(file => regex.test(file));
+    if (!tsFiles.length) {
+      done();
+      return;
+    }
+    args = args.concat(tsFiles);
+  } else {
+    args = args.concat([
+      `${src}/**/*.tsx`,
+      'tests/**/*.tsx',
+      'examples/**/*.tsx',
+    ]);
+  }
+
   runCmd('node', args, done);
 });
 
@@ -616,8 +643,13 @@ gulp.task('react-native-init', done => {
 });
 
 gulp.task('prettier', () => {
+  let fileList = (argv._ || []).slice(1);
+  if (!fileList.length) {
+    fileList = ['./src/**/*.{js,jsx}', './tests/**/*.{js,jsx}', './code/**/*.{js,jsx}'];
+  }
+
   return gulp
-    .src(['./src/**/*.{js,jsx}', './tests/**/*.{js,jsx}', './code/**/*.{js,jsx}'])
+    .src(fileList)
     .pipe(
       prettier(
         {
@@ -638,6 +670,8 @@ gulp.task('prettier', () => {
     )
     .pipe(gulp.dest(file => file.base));
 });
+
+gulp.task('pre-commit', ['prettier', 'lint']);
 
 gulp.task('test:react-15', done => {
   console.log(chalk.yellow('Install react 15 dependenicy...'));

--- a/lib/gulpfile.js
+++ b/lib/gulpfile.js
@@ -132,7 +132,7 @@ gulp.task('ts-lint', ['check-deps'], done => {
     tslintConfig,
   ];
   if (fileList.length) {
-    const regex = /\.tsx$/i;
+    const regex = /\.tsx?$/i;
     const tsFiles = fileList.filter(file => regex.test(file));
     if (!tsFiles.length) {
       done();
@@ -141,9 +141,9 @@ gulp.task('ts-lint', ['check-deps'], done => {
     args = args.concat(tsFiles);
   } else {
     args = args.concat([
-      `${src}/**/*.tsx`,
-      'tests/**/*.tsx',
-      'examples/**/*.tsx',
+      `${src}/**/*{.ts,.tsx}`,
+      'tests/**/*{.ts,.tsx}',
+      'examples/**/*{.ts,.tsx}',
     ]);
   }
 

--- a/lib/gulpfile.js
+++ b/lib/gulpfile.js
@@ -120,7 +120,6 @@ gulp.task('js-lint', ['check-deps'], done => {
 
 gulp.task('ts-lint', ['check-deps'], done => {
   const fileList = (argv._ || []).slice(1);
-
   const tslintBin = require.resolve('tslint/bin/tslint');
   let tslintConfig = path.join(__dirname, './tslint.json');
   const projectTslint = resolveCwd('./tslint.json');


### PR DESCRIPTION
添加 `pre-commit`，在 commit 时自动 prettier + lint:
`package.json` 调整:
```json
{
  "scripts": {
    "pre-commit": "rc-tools run pre-commit",
    "lint-staged": "lint-staged",
  },
  "pre-commit": [
    "lint-staged"
  ],
  "lint-staged": {
    "*.{js,jsx,tsx}": ["npm run pre-commit", "git add"]
  }
}
```

复用了原本的 `lint` 和 `prettier`，添加文件判断以接通 lint-staged。