### PR TITLE
feat: Unique scripts

### DIFF
--- a/lib/FileSizeReporter.js
+++ b/lib/FileSizeReporter.js
@@ -31,9 +31,9 @@ function getDifferenceLabel(currentSize, previousSize) {
   const fileSize = !Number.isNaN(difference) ? filesize(difference) : 0;
   if (difference >= FIFTY_KILOBYTES) {
     return chalk.red('+' + fileSize);
-  } else if (difference < FIFTY_KILOBYTES && difference > 0) {
+  } if (difference < FIFTY_KILOBYTES && difference > 0) {
     return chalk.yellow('+' + fileSize);
-  } else if (difference < 0) {
+  } if (difference < 0) {
     return chalk.green(fileSize);
   }
   return '';

--- a/lib/getWebpackCommonConfig.js
+++ b/lib/getWebpackCommonConfig.js
@@ -2,12 +2,12 @@
 
 const path = require('path');
 const fs = require('fs');
-const resolveCwd = require('./resolveCwd');
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const assign = require('object-assign');
+const resolveCwd = require('./resolveCwd');
 const getBabelCommonConfig = require('./getBabelCommonConfig');
 const getTSCommonConfig = require('./getTSCommonConfig');
 const constants = require('./constants');
-const assign = require('object-assign');
 const replaceLib = require('./replaceLib');
 
 const tsConfig = getTSCommonConfig();

--- a/lib/gulpTasks/cleanTasks.js
+++ b/lib/gulpTasks/cleanTasks.js
@@ -1,0 +1,63 @@
+const fs = require('fs');
+const shelljs = require('shelljs');
+const resolveCwd = require('../resolveCwd');
+
+function cleanCompile() {
+  try {
+    if (fs.existsSync(resolveCwd('lib'))) {
+      shelljs.rm('-rf', resolveCwd('lib'));
+    }
+    if (fs.existsSync(resolveCwd('es'))) {
+      shelljs.rm('-rf', resolveCwd('es'));
+    }
+    if (fs.existsSync(resolveCwd('assets'))) {
+      shelljs.rm('-rf', resolveCwd('assets/*.css'));
+    }
+  } catch (err) {
+    console.log('Clean up failed:', err);
+    throw err;
+  }
+}
+
+function cleanBuild() {
+  if (fs.existsSync(resolveCwd('build'))) {
+    shelljs.rm('-rf', resolveCwd('build'));
+  }
+}
+
+function clean() {
+  cleanCompile();
+  cleanBuild();
+}
+
+function registerTasks(gulp) {
+  gulp.task(
+    'clean',
+    gulp.series(done => {
+      clean();
+      done();
+    })
+  );
+  
+  gulp.task(
+    'cleanCompile',
+    gulp.series(done => {
+      cleanCompile();
+      done();
+    })
+  );
+  
+  gulp.task(
+    'cleanBuild',
+    gulp.series(done => {
+      cleanBuild();
+      done();
+    })
+  );
+}
+
+registerTasks.cleanCompile = cleanCompile;
+registerTasks.cleanBuild = cleanBuild;
+registerTasks.clean = clean;
+
+module.exports = registerTasks;

--- a/lib/gulpTasks/pageTasks.js
+++ b/lib/gulpTasks/pageTasks.js
@@ -1,0 +1,173 @@
+/**
+ * Page related functions
+ * - build
+ * - gh-pages
+ */
+
+const jsx2example = require('gulp-jsx2example');
+const glob = require('glob');
+const fs = require('fs');
+const path = require('path');
+const shelljs = require('shelljs');
+const chalk = require('chalk');
+const webpack = require('webpack');
+const storybook = require('@storybook/react/standalone');
+const resolveCwd = require('../resolveCwd');
+const genStorybook = require('../genStorybook');
+const InitStoryConfigJs = require('../initStoryConfigJs');
+const getWebpackConfig = require('../getWebpackConfig');
+
+const projectPath = resolveCwd('./');
+const pkg = require(resolveCwd('package.json'));
+
+module.exports = function(gulp) {
+  const { cleanBuild } = require('./cleanTasks');
+  const { printResult } = require('./util');
+
+  const isStorybook = !glob.sync('examples/*.html').length;
+
+  // ====================== Webpack ======================
+  function webpackJS() {
+    return new Promise((resolve, reject) => {
+      webpack(
+        getWebpackConfig({
+          common: true,
+        }),
+        (err, stats) => {
+          if (err) {
+            console.error('error', err);
+          }
+          printResult(stats);
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        },
+      );
+    });
+  }
+
+  function webpackBuild(done) {
+    console.log('[webpack] building...');
+    if (!fs.existsSync(resolveCwd('./examples/'))) {
+      console.log(chalk.red('😢 `examples` folder not exist. exit...'));
+      done();
+      return;
+    }
+
+    // Execute webpack
+    webpackJS()
+      .then(() => {
+        // Merge files into build folder
+        console.log('[webpack] Render HTML...');
+        const dir = resolveCwd('./examples/');
+        let files = fs.readdirSync(dir);
+        files = files
+          .filter((f) => f[0] !== '~') // Remove '~tmp' file
+          .map((f) => path.join(dir, f));
+        const filesMap = {};
+        files.forEach((f) => {
+          filesMap[f] = 1;
+        });
+        files.forEach((f) => {
+          if (f.match(/\.tsx?$/)) {
+            let js = f.replace(/\.tsx?$/, '.js');
+            if (filesMap[js]) {
+              delete filesMap[js];
+            }
+            js = f.replace(/\.tsx?$/, '.jsx');
+            if (filesMap[js]) {
+              delete filesMap[js];
+            }
+          }
+        });
+        gulp
+          .src(Object.keys(filesMap))
+          .pipe(
+            jsx2example({
+              dest: 'build/examples/',
+            }),
+          ) // jsx2example(options)
+          .pipe(gulp.dest('build/examples/'))
+          .on('finish', done);
+      })
+      .catch(done);
+  }
+
+  // ===================== Storybook =====================
+  gulp.task('storybook', () => {
+    // 生成 storybook 的配置文件
+    genStorybook(projectPath);
+
+    InitStoryConfigJs(projectPath, pkg);
+    storybook({
+      mode: 'dev',
+      port: '9001',
+      configDir: path.join(__dirname, '../storybook/'),
+    });
+  });
+
+  function storybookBuild(done) {
+    console.log('[storybook] building...');
+    InitStoryConfigJs(projectPath, pkg);
+
+    storybook({
+      mode: 'static',
+      // 相对路径，storybook 会自动拼接 cmd 所在的位置
+      outputDir: './build',
+      configDir: path.join(__dirname, '../storybook/'),
+    }).then(done);
+  }
+
+  gulp.task('storybook-build', (done) => {
+    console.log(chalk.red('💩 `storybook-build` is removed. Use `build` directly!'));
+    done('removed');
+  });
+  gulp.task('storybook-gh-pages', (done) => {
+    console.log(chalk.red('💩 `storybook-gh-pages` is removed. Use `gh-pages` directly!'));
+    done('removed');
+  });
+
+  // ====================== Export =======================
+  gulp.task(
+    'build',
+    gulp.series('cleanBuild', (done) => {
+      if (isStorybook) {
+        storybookBuild(done);
+      } else {
+        webpackBuild(done);
+      }
+    }),
+  );
+
+  gulp.task(
+    'gh-pages',
+    gulp.series('build', (done) => {
+      console.log('[storybook] gh-paging...');
+      if (pkg.scripts['pre-gh-pages']) {
+        shelljs.exec('npm run pre-gh-pages');
+      }
+      if (fs.existsSync(resolveCwd('./build/'))) {
+        console.log(chalk.green('🏁 uploading...'));
+        const ghPages = require('gh-pages');
+        ghPages.publish(
+          resolveCwd('build'),
+          {
+            logger(message) {
+              console.log(message);
+            },
+          },
+          () => {
+            cleanBuild();
+            console.log('gh-paged');
+            done();
+          },
+        );
+      } else {
+        console.log(chalk.red('😢 `build` folder not exist. exit...'));
+        done();
+      }
+    }),
+  );
+};

--- a/lib/gulpTasks/util.js
+++ b/lib/gulpTasks/util.js
@@ -1,0 +1,18 @@
+function printResult(stats) {
+  if (stats.toJson) {
+    stats = stats.toJson();
+  }
+
+  (stats.errors || []).forEach(err => {
+    console.error('error', err);
+  });
+
+  stats.assets.forEach(item => {
+    const size = `${(item.size / 1024.0).toFixed(2)}kB`;
+    console.log('generated', item.name, size);
+  });
+}
+
+module.exports = {
+  printResult,
+};

--- a/lib/gulpfile.js
+++ b/lib/gulpfile.js
@@ -5,7 +5,6 @@ const path = require('path');
 const through2 = require('through2');
 const webpack = require('webpack');
 const shelljs = require('shelljs');
-const jsx2example = require('gulp-jsx2example');
 const babel = require('gulp-babel');
 const fs = require('fs-extra');
 const argv = require('minimist')(process.argv.slice(2));
@@ -16,7 +15,6 @@ const merge2 = require('merge2');
 const glob = require('glob');
 const watch = require('gulp-watch');
 const assign = require('object-assign');
-const storybook = require('@storybook/react/standalone');
 const targz = require('tar.gz');
 const request = require('request');
 const minify = require('gulp-babel-minify');
@@ -31,9 +29,9 @@ const tsConfig = require('./getTSCommonConfig')();
 const { tsCompiledDir } = require('./constants');
 const { measureFileSizesBeforeBuild, printFileSizesAfterBuild } = require('./FileSizeReporter');
 const replaceLib = require('./replaceLib');
-const InitStoryConfigJs = require('./initStoryConfigJs');
-const selfPackage = require('../package.json');
+const { printResult } = require('./gulpTasks/util');
 const genStorybook = require('./genStorybook');
+const selfPackage = require('../package.json');
 
 const pkg = require(resolveCwd('package.json'));
 const cwd = process.cwd();
@@ -100,74 +98,17 @@ export default class Portal extends React.Component {
 }
 `;
 
-function printResult(stats) {
-  if (stats.toJson) {
-    stats = stats.toJson();
-  }
+// ============================== Clean ==============================
+const cleanTasks = require('./gulpTasks/cleanTasks');
 
-  (stats.errors || []).forEach(err => {
-    console.error('error', err);
-  });
+const { cleanCompile } = cleanTasks;
 
-  stats.assets.forEach(item => {
-    const size = `${(item.size / 1024.0).toFixed(2)}kB`;
-    console.log('generated', item.name, size);
-  });
-}
+cleanTasks(gulp);
 
-function cleanCompile() {
-  try {
-    if (fs.existsSync(resolveCwd('lib'))) {
-      shelljs.rm('-rf', resolveCwd('lib'));
-    }
-    if (fs.existsSync(resolveCwd('es'))) {
-      shelljs.rm('-rf', resolveCwd('es'));
-    }
-    if (fs.existsSync(resolveCwd('assets'))) {
-      shelljs.rm('-rf', resolveCwd('assets/*.css'));
-    }
-  } catch (err) {
-    console.log('Clean up failed:', err);
-    throw err;
-  }
-}
-
-function cleanBuild() {
-  if (fs.existsSync(resolveCwd('build'))) {
-    shelljs.rm('-rf', resolveCwd('build'));
-  }
-}
-
-function clean() {
-  cleanCompile();
-  cleanBuild();
-}
+// ============================== Pages ==============================
+require('./gulpTasks/pageTasks')(gulp);
 
 // ============================== MISC ===============================
-gulp.task(
-  'clean',
-  gulp.series(done => {
-    clean();
-    done();
-  })
-);
-
-gulp.task(
-  'cleanCompile',
-  gulp.series(done => {
-    cleanCompile();
-    done();
-  })
-);
-
-gulp.task(
-  'cleanBuild',
-  gulp.series(done => {
-    cleanBuild();
-    done();
-  })
-);
-
 gulp.task(
   'check-deps',
   gulp.series(done => {
@@ -313,98 +254,6 @@ gulp.task('test', done => {
 
   done(ret.code);
 });
-
-// ============================ Build Web ============================
-gulp.task(
-  'webpack',
-  gulp.series('cleanBuild', done => {
-    if (fs.existsSync(resolveCwd('./examples/'))) {
-      webpack(
-        getWebpackConfig({
-          common: true,
-        }),
-        (err, stats) => {
-          if (err) {
-            console.error('error', err);
-          }
-          printResult(stats);
-          done(err);
-        }
-      );
-    } else {
-      done();
-    }
-  })
-);
-
-gulp.task(
-  'build',
-  gulp.series('webpack', done => {
-    if (fs.existsSync(resolveCwd('./examples/'))) {
-      const dir = resolveCwd('./examples/');
-      let files = fs.readdirSync(dir);
-      files = files
-        .filter(f => f[0] !== '~') // Remove '~tmp' file
-        .map(f => path.join(dir, f));
-      const filesMap = {};
-      files.forEach(f => {
-        filesMap[f] = 1;
-      });
-      files.forEach(f => {
-        if (f.match(/\.tsx?$/)) {
-          let js = f.replace(/\.tsx?$/, '.js');
-          if (filesMap[js]) {
-            delete filesMap[js];
-          }
-          js = f.replace(/\.tsx?$/, '.jsx');
-          if (filesMap[js]) {
-            delete filesMap[js];
-          }
-        }
-      });
-      gulp
-        .src(Object.keys(filesMap))
-        .pipe(
-          jsx2example({
-            dest: 'build/examples/',
-          })
-        ) // jsx2example(options)
-        .pipe(gulp.dest('build/examples/'))
-        .on('finish', done);
-      return;
-    }
-    done();
-  })
-);
-
-gulp.task(
-  'gh-pages',
-  gulp.series('build', done => {
-    console.log('gh-paging');
-    if (pkg.scripts['pre-gh-pages']) {
-      shelljs.exec('npm run pre-gh-pages');
-    }
-    if (fs.existsSync(resolveCwd('./examples/'))) {
-      const ghPages = require('gh-pages');
-      ghPages.publish(
-        resolveCwd('build'),
-        {
-          depth: 1,
-          logger(message) {
-            console.log(message);
-          },
-        },
-        () => {
-          cleanBuild();
-          console.log('gh-paged');
-          done();
-        }
-      );
-    } else {
-      done();
-    }
-  })
-);
 
 // ============================= Package =============================
 gulp.task('css', () => {
@@ -894,68 +743,5 @@ gulp.task(
     const dir = resolveCwd('./');
     genStorybook(dir);
     done();
-  })
-);
-
-gulp.task('genStorybook', gulp.series('runGenStorybook', 'prettier'));
-
-gulp.task('storybook', () => {
-  // get project name
-  const dir = resolveCwd('./');
-  const config = require(path.join(dir, './package.json'));
-
-  // 生成 storybook 的配置文件
-  genStorybook(dir);
-
-  InitStoryConfigJs(dir, config);
-  storybook({
-    mode: 'dev',
-    port: '9001',
-    configDir: path.join(__dirname, './storybook/'),
-  });
-});
-
-gulp.task('storybook-build', () => {
-  const dir = resolveCwd('./');
-  // remove ./build
-  const config = require(path.join(dir, './package.json'));
-  const buildFolder = resolveCwd('./build');
-  shelljs.rm('-rf', buildFolder);
-
-  InitStoryConfigJs(dir, config);
-
-  storybook({
-    mode: 'static',
-    // 相对路径，storybook 会自动拼接 cmd 所在的位置
-    outputDir: './build',
-    configDir: path.join(__dirname, './storybook/'),
-  });
-});
-
-gulp.task(
-  'storybook-gh-pages',
-  gulp.series(done => {
-    console.log('gh-paging');
-    if (pkg.scripts['pre-gh-pages']) {
-      shelljs.exec('npm run pre-gh-pages');
-    }
-    if (fs.existsSync(resolveCwd('./build/'))) {
-      const ghPages = require('gh-pages');
-      ghPages.publish(
-        resolveCwd('build'),
-        {
-          logger(message) {
-            console.log(message);
-          },
-        },
-        () => {
-          cleanBuild();
-          console.log('gh-paged');
-          done();
-        }
-      );
-    } else {
-      done();
-    }
   })
 );


### PR DESCRIPTION
* 修复使用 storybook 发布版本不能更新 gh-pages 的问题。
* 统一了 storybook 和老式写法，现在在脚本中不需要区分 webpack 和 storybook 上下文。将会自动处理：

```diff
- rc-tools run storybook-build
+ rc-tools run build

- rc-tools run storybook-gh-pages
+ rc-tools run gh-pages
```